### PR TITLE
pacman & makepkg

### DIFF
--- a/chroot-script.sh
+++ b/chroot-script.sh
@@ -99,7 +99,7 @@ else
 fi
 
 
-"[Trigger]
+echo "[Trigger]
 Type = Package
 Operation = Upgrade
 Target = systemd


### PR DESCRIPTION
combine related sed commands modifying /etc/pacman.conf into one to reduce redundancy and adding the command sed -i "s/-j2/-j$(nproc)/;/^#MAKEFLAGS/s/^#//" /etc/makepkg.conf would be beneficial for utilizing all cores during compilation