### PR TITLE
Add rootfstype=xfs option to systemd-boot entries

### DIFF
--- a/chroot-script.sh
+++ b/chroot-script.sh
@@ -1,7 +1,6 @@
 #!bin/sh
 
-if ! [ $timezone ]
-then
+if ! [ $timezone ]; then
   timezone="Europe/Lisbon"
 fi
 
@@ -9,52 +8,45 @@ ln -sf /usr/share/zoneinfo/$timezone /etc/localtime
 hwclock --systohc
 sed -i "/^#en_US.UTF-8/ cen_US.UTF-8 UTF-8" /etc/locale.gen
 locale-gen
-echo "LANG=en_US.UTF-8" >> /etc/locale.conf
+echo "LANG=en_US.UTF-8" >>/etc/locale.conf
 
-if ! [ $hostname ]
-then
+if ! [ $hostname ]; then
   hostname="arch"
 fi
 
-echo $hostname >> /etc/hostname
+echo $hostname >>/etc/hostname
 
-if ! [ $editor ]
-then
+if ! [ $editor ]; then
   editor="neovim"
 fi
 
 pacman --noconfirm -Sy efibootmgr $editor base-devel git
 
 case $network in
-  systemd-networkd)
-    systemctl enable systemd-networkd
-    systemctl enable systemd-resolved
-    ;;
+systemd-networkd)
+  systemctl enable systemd-networkd
+  systemctl enable systemd-resolved
+  ;;
 
-  dhcpcd)
-    pacman --noconfirm -S dhcpcd
-    systemctl enable dhcpcd
-    ;;
-  
-  none)
-    ;;
-   
-  *)
-    pacman --noconfirm -S networkmanager
-    systemctl enable NetworkManager
-    ;;
+dhcpcd)
+  pacman --noconfirm -S dhcpcd
+  systemctl enable dhcpcd
+  ;;
+
+none) ;;
+
+*)
+  pacman --noconfirm -S networkmanager
+  systemctl enable NetworkManager
+  ;;
 esac
 
-
-if [[ $(grep 'AuthenticAMD' </proc/cpuinfo | head -n 1) ]]
-then
+if [[ $(grep 'AuthenticAMD' </proc/cpuinfo | head -n 1) ]]; then
   cpu=amd
-elif [[ $(grep 'GenuineIntel' </proc/cpuinfo | head -n 1) ]]
-then
+elif [[ $(grep 'GenuineIntel' </proc/cpuinfo | head -n 1) ]]; then
   cpu=intel
 fi
-if [ $cpu ]
-then
+if [ $cpu ]; then
   pacman --noconfirm -S $cpu-ucode
 fi
 
@@ -64,41 +56,35 @@ mkdir -p /boot/loader/entries /etc/pacman.d/hooks
 echo "default  arch.conf 
 timeout  4 
 console-mode max 
-editor  yes" > /boot/loader/loader.conf
- 
+editor  yes" >/boot/loader/loader.conf
+
 echo "title  Arch Linux 
-linux  /vmlinuz-$kernel" > /boot/loader/entries/arch.conf
-if [ $cpu ]
-then
-  echo "initrd  /$cpu-ucode.img" >> /boot/loader/entries/arch.conf
+linux  /vmlinuz-$kernel" >/boot/loader/entries/arch.conf
+if [ $cpu ]; then
+  echo "initrd  /$cpu-ucode.img" >>/boot/loader/entries/arch.conf
 fi
 echo "initrd  /initramfs-$kernel.img
-options  root=$(cat /etc/fstab | grep 'UUID' | head -n 1 - | awk '{print $1}') rw" >> /boot/loader/entries/arch.conf
- 
-if [ "$gpu" == "nvidia" ]
-then
-  echo "options  mitigations=off nvidia-drm.modeset=1" >> /boot/loader/entries/arch.conf
+options  root=$(cat /etc/fstab | grep 'UUID' | head -n 1 - | awk '{print $1}') rw rootfstype=xfs" >>/boot/loader/entries/arch.conf
+
+if [ "$gpu" == "nvidia" ]; then
+  echo "options  mitigations=off nvidia-drm.modeset=1" >>/boot/loader/entries/arch.conf
 else
-  echo "options  mitigations=off" >> /boot/loader/entries/arch.conf
-fi
- 
- 
-echo "title  Arch Linux Fallback 
-linux  /vmlinuz-$kernel" > /boot/loader/entries/arch-fallback.conf
-if [ $cpu ]
-then
-  echo "initrd  /$cpu-ucode.img" >> /boot/loader/entries/arch-fallback.conf
-fi
-echo "initrd  /initramfs-$kernel-fallback.img
-options  root=PART$(cat /etc/fstab | grep 'UUID' | head -n 1 - | awk '{print $1}') rw" >> /boot/loader/entries/arch-fallback.conf
- 
-if [ "$gpu" == "nvidia" ]
-then
-  echo "options  mitigations=off nvidia-drm.modeset=1" >> /boot/loader/entries/arch-fallback.conf
-else
-  echo "options  mitigations=off" >> /boot/loader/entries/arch-fallback.conf
+  echo "options  mitigations=off" >>/boot/loader/entries/arch.conf
 fi
 
+echo "title  Arch Linux Fallback 
+linux  /vmlinuz-$kernel" >/boot/loader/entries/arch-fallback.conf
+if [ $cpu ]; then
+  echo "initrd  /$cpu-ucode.img" >>/boot/loader/entries/arch-fallback.conf
+fi
+echo "initrd  /initramfs-$kernel-fallback.img
+options  root=PART$(cat /etc/fstab | grep 'UUID' | head -n 1 - | awk '{print $1}') rw rootfstype=xfs" >>/boot/loader/entries/arch-fallback.conf
+
+if [ "$gpu" == "nvidia" ]; then
+  echo "options  mitigations=off nvidia-drm.modeset=1" >>/boot/loader/entries/arch-fallback.conf
+else
+  echo "options  mitigations=off" >>/boot/loader/entries/arch-fallback.conf
+fi
 
 echo "[Trigger]
 Type = Package
@@ -108,25 +94,21 @@ Target = systemd
 [Action]
 Description = Gracefully upgrading systemd-boot...
 When = PostTransaction
-Exec = /usr/bin/systemctl restart systemd-boot-update.service" > /etc/pacman.d/hooks/100-systemd-boot.hook
+Exec = /usr/bin/systemctl restart systemd-boot-update.service" >/etc/pacman.d/hooks/100-systemd-boot.hook
 
-if [ $winefi ]
-then
+if [ $winefi ]; then
   mount $winefi /mnt
   cp /mnt/EFI /boot/ -r
   umount /mnt
 fi
 
-if ! [ $rootpw ]
-then
+if ! [ $rootpw ]; then
   rootpw="root"
 fi
-if ! [ $username ]
-then
+if ! [ $username ]; then
   username="user"
 fi
-if ! [ $userpw ]
-then
+if ! [ $userpw ]; then
   userpw="user"
 fi
 
@@ -138,8 +120,7 @@ sed -i "/^# %wheel ALL=(ALL:ALL) ALL/ c%wheel ALL=(ALL:ALL) ALL" /etc/sudoers
 sed -Ei "s/^#(ParallelDownloads).*/\1 = 5/;/^#Color$/s/#//" /etc/pacman.conf
 sed -i "s/-j2/-j$(nproc)/;/^#MAKEFLAGS/s/^#//" /etc/makepkg.conf
 
-if ! [ $installtype ] || [ $installtype == "minimal" ]
-then
+if ! [ $installtype ] || [ $installtype == "minimal" ]; then
   exit
 fi
 
@@ -147,64 +128,60 @@ sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
 pacman -Sy
 pacman --noconfirm -S xorg noto-fonts noto-fonts-cjk noto-fonts-emoji noto-fonts-extra pipewire lib32-pipewire wireplumber pipewire-alsa pipewire-pulse pipewire-jack
 
-case $gpu in 
-  nvidia)
-    pacman -S --noconfirm --needed lib32-libglvnd lib32-nvidia-utils lib32-vulkan-icd-loader libglvnd nvidia-dkms nvidia-settings vulkan-icd-loader
-    ;;
-    
-  amd)
-    pacman -S --noconfirm --needed xf86-video-amdgpu mesa lib32-mesa lib32-vulkan-icd-loader lib32-vulkan-radeon vulkan-icd-loader vulkan-radeon
-    ;;
-  
-  intel)
-    pacman -S --noconfirm --needed xf86-video-intel mesa lib32-mesa lib32-vulkan-icd-loader lib32-vulkan-intel vulkan-icd-loader vulkan-intel
-    ;;
-      
-  *)
-    pacman -S --noconfirm xf86-video-amdgpu xf86-video-intel xf86-video-nouveau
-    ;;
+case $gpu in
+nvidia)
+  pacman -S --noconfirm --needed lib32-libglvnd lib32-nvidia-utils lib32-vulkan-icd-loader libglvnd nvidia-dkms nvidia-settings vulkan-icd-loader
+  ;;
+
+amd)
+  pacman -S --noconfirm --needed xf86-video-amdgpu mesa lib32-mesa lib32-vulkan-icd-loader lib32-vulkan-radeon vulkan-icd-loader vulkan-radeon
+  ;;
+
+intel)
+  pacman -S --noconfirm --needed xf86-video-intel mesa lib32-mesa lib32-vulkan-icd-loader lib32-vulkan-intel vulkan-icd-loader vulkan-intel
+  ;;
+
+*)
+  pacman -S --noconfirm xf86-video-amdgpu xf86-video-intel xf86-video-nouveau
+  ;;
 esac
 
-
-if [ $installtype == "desktop" ]
-then
+if [ $installtype == "desktop" ]; then
   case $desktop in
-    kde)
-      pacman -S --noconfirm plasma-pa plasma-nm xdg-desktop-portal-kde kscreen kde-gtk-config breeze-gtk kdeplasma-addons ark sddm konsole dolphin systemsettings plasma-desktop plasma-workspace kinit
-      systemctl enable sddm
-      ;;
-    
-    xfce)
-      pacman -S --noconfirm xfce4 xfce4-goodies lxdm
-      systemctl enable lxdm
-      ;;
-    
-    dwm)
-      if ! [ $dwmrepo ]
-      then
-        dwmrepo="https://github.com/miguelrcborges/dwm.git"
-        deps="maim rofi xterm xclip ttf-jetbrains-mono-nerd"
-        curl -L "https://raw.githubusercontent.com/miguelrcborges/dotfiles/main/Xresources-desktop/.Xresources" -o /home/$username/.Xresources
-        curl -L "https://raw.githubusercontent.com/miguelrcborges/archinstallscript/main/extras/basic_xinitrc" -o /home/$username/.xinitrc
-      fi
-      
-      pacman -S --noconfirm xorg-xinit $deps
-      git clone https://github.com/miguelrcborges/dwm.git /home/$username/repos/dwm
-      cd /home/$username/repos/dwm
-      chown -R $username /home/$username/repos
-      
-      if [ $dwmrefresh ]
-      then
-        sed -i "s/static const unsigned int refresh_rate = [0-9]\+;/static const unsigned int refresh_rate = $dwmrefresh;/g" config.h
-      fi
-      
-      make install
-      cd
-      ;;
-    
-    *)
-      pacman -S --noconfirm mutter gnome-shell gnome-session nautilus gnome-control-center gnome-tweaks xdg-desktop-portal-gnome gdm gnome-terminal 
-      systemctl enable gdm
-      ;;
+  kde)
+    pacman -S --noconfirm plasma-pa plasma-nm xdg-desktop-portal-kde kscreen kde-gtk-config breeze-gtk kdeplasma-addons ark sddm konsole dolphin systemsettings plasma-desktop plasma-workspace kinit
+    systemctl enable sddm
+    ;;
+
+  xfce)
+    pacman -S --noconfirm xfce4 xfce4-goodies lxdm
+    systemctl enable lxdm
+    ;;
+
+  dwm)
+    if ! [ $dwmrepo ]; then
+      dwmrepo="https://github.com/miguelrcborges/dwm.git"
+      deps="maim rofi xterm xclip ttf-jetbrains-mono-nerd"
+      curl -L "https://raw.githubusercontent.com/miguelrcborges/dotfiles/main/Xresources-desktop/.Xresources" -o /home/$username/.Xresources
+      curl -L "https://raw.githubusercontent.com/miguelrcborges/archinstallscript/main/extras/basic_xinitrc" -o /home/$username/.xinitrc
+    fi
+
+    pacman -S --noconfirm xorg-xinit $deps
+    git clone https://github.com/miguelrcborges/dwm.git /home/$username/repos/dwm
+    cd /home/$username/repos/dwm
+    chown -R $username /home/$username/repos
+
+    if [ $dwmrefresh ]; then
+      sed -i "s/static const unsigned int refresh_rate = [0-9]\+;/static const unsigned int refresh_rate = $dwmrefresh;/g" config.h
+    fi
+
+    make install
+    cd
+    ;;
+
+  *)
+    pacman -S --noconfirm mutter gnome-shell gnome-session nautilus gnome-control-center gnome-tweaks xdg-desktop-portal-gnome gdm gnome-terminal
+    systemctl enable gdm
+    ;;
   esac
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
-if [ $root ]
-then
-  mkfs.xfs -f $root || exit && mount $root /mnt && mkdir /mnt/boot 
+if [ $root ]; then
+  mkfs.xfs -f $root || exit && mount $root /mnt && mkdir /mnt/boot
 else
   echo "Root partition not added. Read the README of the github repo."
   exit
 fi
 
-if [ $boot ]
-then
+if [ $boot ]; then
   mkfs.fat -F32 $boot || exit && mount $boot /mnt/boot
 else
   echo "Boot partition not added. Read the README of the github repo."
@@ -17,29 +15,25 @@ else
   exit
 fi
 
-if [ $swap ]
-then
+if [ $swap ]; then
   mkswap $swap || exit && swapon $swap
 fi
 
-if [ $home ]
-then
+if [ $home ]; then
   mkfs.xfs -f $home || exit && mount $home /mnt/home
 fi
 
-if ! [ $kernel ]
-then
+if ! [ $kernel ]; then
   export kernel=linux
 fi
 
-pacstrap /mnt base $kernel $kernel-headers linux-firmware || exit
+pacstrap /mnt base $kernel $kernel-headers linux-firmware xfsprogs || exit
 timedatectl set-ntp true
-genfstab -U /mnt >> /mnt/etc/fstab
+genfstab -U /mnt >>/mnt/etc/fstab
 curl -L https://raw.githubusercontent.com/miguelrcborges/archinstallscript/main/chroot-script.sh -o /mnt/chroot-script.sh
 arch-chroot /mnt sh chroot-script.sh
 
-if [ $network == "systemd-networkd" ]
-then
+if [ $network == "systemd-networkd" ]; then
   cp -r /etc/systemd/network /mnt/etc/systemd/network
 fi
 


### PR DESCRIPTION
The root filesystem is formatted as XFS, so the rootfstype=xfs option has been added to the boot loader entries to specify the file system type. This ensures proper mounting and handling of the root partition.