### PR TITLE
Fix Timeout and Adjust Configuration Paths

### DIFF
--- a/chroot-script.sh
+++ b/chroot-script.sh
@@ -69,7 +69,7 @@ bootctl install
 mkdir -p /boot/loader/entries /etc/pacman.d/hooks
 
 echo "default  arch.conf
-timeout  4
+timeout  3
 console-mode max
 editor  yes" >/boot/loader/loader.conf
 
@@ -130,7 +130,7 @@ fi
 echo "root:$rootpw" | chpasswd
 useradd -mg wheel $username
 echo "$username:$userpw" | chpasswd
-sed -i "/^# %wheel ALL=(ALL:ALL) ALL/ c%wheel ALL=(ALL:ALL) ALL" /etc/sudoers
+echo "$username ALL=(ALL) ALL" >>/etc/sudoers.d/00_$username
 sed -Ei "s/^#(ParallelDownloads).*/\1 = 5/;/^#Color$/s/#//" /etc/pacman.conf
 sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
 sed -i "s/-j2/-j$(nproc)/;/^#MAKEFLAGS/s/^#//" /etc/makepkg.conf

--- a/start.sh
+++ b/start.sh
@@ -47,7 +47,7 @@ curl -L https://raw.githubusercontent.com/miguelrcborges/archinstallscript/main/
 arch-chroot /mnt sh chroot-script.sh
 
 if [ $network == "systemd-networkd" ]; then
-  cp -r /etc/systemd/network /mnt/etc/systemd/network
+  cp -r /etc/systemd/network /mnt/etc/systemd
 fi
 
 reboot


### PR DESCRIPTION
- Timeout Adjustment: Updated `timeout` value in `/boot/loader/loader.conf` from 4 to 3 to match Archinstall defaults.
- Sudoers Configuration: Replaced direct modification of `/etc/sudoers` with adding a new configuration file `/etc/sudoers.d/00_$username` for user-specific sudo permissions.
- Path Adjustment: Modified the script to copy network configuration files to `/mnt/etc/systemd` instead of creating a new `network` directory within `/etc/systemd`, ensuring compatibility with systemd-networkd.